### PR TITLE
Ignore case

### DIFF
--- a/special.go
+++ b/special.go
@@ -25,6 +25,8 @@ func NewSpecialTest(keyword string, input interface{}) (Test, error) {
 		return NewContainsNoneTest(input)
 	case "$startsWith":
 		return NewStartsWithTest(input)
+	case "$ignoreCase":
+		return NewCaseInsensitiveStringTest(input)
 	}
 
 	if number, ok := castNumber(input); ok {

--- a/special.go
+++ b/special.go
@@ -25,6 +25,8 @@ func NewSpecialTest(keyword string, input interface{}) (Test, error) {
 		return NewContainsNoneTest(input)
 	case "$startsWith":
 		return NewStartsWithTest(input)
+	case "$startsWithIgnoreCase":
+		return NewStartsWithInsensitiveTest(input)
 	case "$ignoreCase":
 		return NewCaseInsensitiveStringTest(input)
 	}

--- a/startswithInsensitive.go
+++ b/startswithInsensitive.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// $startsWithIgnoreCase
+type startsWithInsensitiveTest struct {
+	expectedStart string
+}
+
+func NewStartsWithInsensitiveTest(input interface{}) (Test, error) {
+	castedString, ok := castString(input)
+	if !ok {
+		return nil, fmt.Errorf("value for $startsWithIgnoreCase is not a string (%#v %v)", input, reflect.TypeOf(input))
+	}
+
+	lowerCaseString := strings.ToLower(castedString)
+	return &startsWithInsensitiveTest{
+		expectedStart: lowerCaseString,
+	}, nil
+}
+
+func (swt *startsWithInsensitiveTest) Run(input interface{}) error {
+	castedString, ok := castString(input)
+	if !ok {
+		return fmt.Errorf("input (%#v %v) isn't a string", input, reflect.TypeOf(input))
+	}
+
+	if !strings.HasPrefix(strings.ToLower(castedString), swt.expectedStart) {
+		return fmt.Errorf("%q does not start with %q", castedString, swt.expectedStart)
+	}
+
+	return nil
+
+}
+
+func (swt *startsWithInsensitiveTest) IsMetaTest() bool {
+	return true
+}

--- a/startswithinsensitive_test.go
+++ b/startswithinsensitive_test.go
@@ -1,0 +1,51 @@
+package tests_test
+
+import (
+	"testing"
+
+	tests "github.com/fino-digital/json-rule-engine"
+)
+
+func TestStartsWithInsensitiveTestWrongExpectedValue(t *testing.T) {
+	_, err := tests.NewStartsWithInsensitiveTest(123)
+
+	if err == nil {
+		t.Error("test should have only accepted strings as input")
+	}
+}
+
+func TestStartsWithInsensitiveTestWrongType(t *testing.T) {
+	test, err := tests.NewStartsWithInsensitiveTest("test")
+	if err != nil {
+		t.Error("failed to create test", err)
+	}
+
+	err = test.Run(123)
+	if err == nil {
+		t.Error("should have failed when number was passed as input")
+	}
+}
+
+func TestStartsWithInsensitiveTestWrongInput(t *testing.T) {
+	test, err := tests.NewStartsWithInsensitiveTest("test")
+	if err != nil {
+		t.Error("failed to create test", err)
+	}
+
+	err = test.Run("pew")
+	if err == nil {
+		t.Error("should have failed when non matching input was passed")
+	}
+}
+
+func TestStartsWithInsensitiveTestCorrectInput(t *testing.T) {
+	test, err := tests.NewStartsWithInsensitiveTest("TEST")
+	if err != nil {
+		t.Error("failed to create test", err)
+	}
+
+	err = test.Run("test2")
+	if err != nil {
+		t.Error("test should not have failed when given correct input")
+	}
+}

--- a/stringInsensitive.go
+++ b/stringInsensitive.go
@@ -1,0 +1,39 @@
+package tests
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type stringInsensitiveTest struct {
+	expected string
+}
+
+func (st *stringInsensitiveTest) Run(input interface{}) error {
+	castedString, ok := castString(input)
+	if !ok {
+		return fmt.Errorf("input (%#v %v) isn't a string", input, reflect.TypeOf(input))
+	}
+
+	if !strings.EqualFold(castedString, st.expected) {
+		return fmt.Errorf("%q is not case insensitive equal to %q", castedString, st.expected)
+	}
+
+	return nil
+
+}
+
+func (st *stringInsensitiveTest) IsMetaTest() bool {
+	return false
+}
+
+func NewCaseInsensitiveStringTest(expected interface{}) (Test, error) {
+	if castedString, ok := castString(expected); ok {
+		return &stringInsensitiveTest{
+			expected: castedString,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("couldn't create test for value %#v", expected)
+}

--- a/stringInsensitive_test.go
+++ b/stringInsensitive_test.go
@@ -1,0 +1,34 @@
+package tests_test
+
+import (
+	"testing"
+
+	tests "github.com/fino-digital/json-rule-engine"
+)
+
+func TestInsensitiveStringTestWrongType(t *testing.T) {
+	test, err := tests.NewCaseInsensitiveStringTest("test")
+
+	err = test.Run(123)
+	if err == nil {
+		t.Error("should have failed when number was passed as input")
+	}
+}
+
+func TestInsensitiveStringTestWrongInput(t *testing.T) {
+	test, err := tests.NewCaseInsensitiveStringTest("test")
+
+	err = test.Run("pew")
+	if err == nil {
+		t.Error("should have failed when non matching input was passed")
+	}
+}
+
+func TestInsensitiveStringTestCorrectInput(t *testing.T) {
+	test, err := tests.NewCaseInsensitiveStringTest("Test")
+
+	err = test.Run("test")
+	if err != nil {
+		t.Error("test should not have failed when given correct input")
+	}
+}


### PR DESCRIPTION
I created two new rules in order to compare fields in a case insensitive manner:

- `$startsWithIgnoreCase`: compares the prefix
- `$ignoreCase`: check for case insensitive identity
